### PR TITLE
changed slog.a to libslog.a in order to follow GCC's linker-options convention (https://gcc.gnu.org/onlinedocs/gcc/Link-Options.html)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -4,8 +4,8 @@ OBJS = slog.o
 .c.o:
 	$(CC) $(CFLAGS) -c $< $(LIB)
 
-slog.a: $(OBJS)
-	$(AR) rcs slog.a $(OBJS)
+libslog.a: $(OBJS)
+	$(AR) rcs libslog.a $(OBJS)
 	@echo [-] Syncing static library
 	sync
 
@@ -13,4 +13,4 @@ slog.o: slog.h
 
 .PHONY: clean
 clean:
-	$(RM) slog.a $(OBJS)
+	$(RM) libslog.a $(OBJS)


### PR DESCRIPTION
As you might've noticed already Slog can't be found by the gcc-compiler when using the -lLIBNAME option. For example:  -lslog
It won't find it, even if you add a -L path to your build-cmd.

In order to make it work, GCC's -l option expects the library name in the following format:  libLIBNAME.a  (https://gcc.gnu.org/onlinedocs/gcc/Link-Options.html)
That's why I changed the name to **libslog.a** and now it can be used correctly.

---

People could also link it without the -l option  (gcc [....] slog.a) - however - it doesn't really fit GCC's linker-style and not a library in general. A library should be prefixed.
