### PR TITLE
fix for loop initial declaration

### DIFF
--- a/src/slog.c
+++ b/src/slog.c
@@ -169,7 +169,9 @@ void slog_prepare_output(const char* pStr, const SlogDate *pDate, int nType, int
                     pDate->min, pDate->sec, pDate->usec);
 
     /* Walk throu */
-    for (int i = 0;; i++)
+    int i;
+    for (i = 0;; i++)
+    //for (int i = 0;; i++)
     {
         if ((nType == SLOG_NONE) && !g_SlogTags[i].nType && (g_SlogTags[i].pDesc == NULL))
         {


### PR DESCRIPTION
root@lpgaixmgmtlx01:/root/git/slog/src>make
cc -g -O2 -Wall -lpthread -c slog.c -lrt
slog.c: In function ‘slog_prepare_output’:
slog.c:172:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
     for (int i = 0;; i++)
     ^
slog.c:172:5: note: use option -std=c99 or -std=gnu99 to compile your code
make: *** [slog.o] Error 1
