### PR TITLE
Added missing Import stddef.h

### DIFF
--- a/src/slog.h
+++ b/src/slog.h
@@ -30,6 +30,7 @@ extern "C" {
 #endif
 
 #include <inttypes.h>
+#include <stddef.h>
 #include <stdint.h>
 
 /* SLog version information */


### PR DESCRIPTION
Hello. I was having an Issue with the newest Release, where the Compiler would complain when compiling my personal Project, when I was using this libary. The compiler gives me the following Error
```bash
In file included from /home/meiko/repos/openvpn-client-private/src/utils/vpnManager.c:1:
/usr/local/include/slog.h:101:44: error: unknown type name ‘size_t’
  101 | typedef int (*slog_cb_t)(const char *pLog, size_t nLength, slog_flag_t eFlag,
      |                                            ^~~~~~
/usr/local/include/slog.h:33:1: note: ‘size_t’ is defined in header ‘<stddef.h>’; did you forget to ‘#include <stddef.h>’?
   32 | #include <inttypes.h>
  +++ |+#include <stddef.h>
   33 | #include <stdint.h>
/usr/local/include/slog.h:162:5: error: unknown type name ‘slog_cb_t’
  162 |     slog_cb_t logCallback;         // Log callback to collect logs
      |     ^~~~~~~~~
/usr/local/include/slog.h:185:24: error: unknown type name ‘slog_cb_t’; did you mean ‘slog_flag_t’?
  185 | void slog_callback_set(slog_cb_t callback, void *pContext);
      |                        ^~~~~~~~~
      |                        slog_flag_t
```

To my luck the compiler also gives me the solution. Just adding `#include <stddef.h>` fixed it for me. So I just applied this simple fix.